### PR TITLE
Fixed hiding function scope variable

### DIFF
--- a/pkg/deviceplugin/runner.go
+++ b/pkg/deviceplugin/runner.go
@@ -47,7 +47,8 @@ func (r *Runner) Run() {
 				}
 			}
 
-			devicePlugin, err := NewHostPathDevicePlugin(r.cfg)
+			var err error
+			devicePlugin, err = NewHostPathDevicePlugin(r.cfg)
 			if err != nil {
 				log.Fatal().Err(err).Msg("Failed to initialize HostPath device plugin")
 			}


### PR DESCRIPTION
Restart always skips stop due to null. On the other hand, shutdown causes null pointer dereference.