### PR TITLE
Fix release.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,5 +70,4 @@ jobs:
     - name: Validate
       uses: goreleaser/goreleaser-action@v3
       with:
-        version: latest
         args: release --snapshot --skip=publish --clean --verbose

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,6 @@ jobs:
     - name: GoReleaser
       uses: goreleaser/goreleaser-action@v3
       with:
-        args: release --rm-dist --debug
+        args: release --clean --verbose
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The PR fixes the release workflow that failed in the previous release https://github.com/everpeace/k8s-hostpath-device-plugin/actions/runs/11123138746.

- It should use `--clean --verbose` instead of `--rm-dist --debug` because it doesn't work anymore.
- The goreleaser version should match between `release.yml` and `ci.yml`



